### PR TITLE
Support environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,13 @@ To see all available configuration flags:
 
     ./pgbouncer_exporter -h
 
+## Flags
+
+|Flag / Environment Variable|Default|Description|
+|---------------------------|-------|-----------|
+`pgBouncer.connectionString`<br>`PGBOUNCER_EXPORTER_CONNECTION_STRING` | postgres://postgres:@localhost:6543/pgbouncer?sslmode=disable | Connection string for accessing pgBouncer
+`web.listen-address`<br>`PGBOUNCER_EXPORTER_WEB_LISTEN_ADDRESS` | 9127 | Address on which to expose metrics and web interface
+`web.telemetry-path`<br>`PGBOUNCER_EXPORTER_WEB_TELEMETRY_PATH` | /metrics | Path under which to expose metrics
 
 ## Metrics
 

--- a/pgbouncer_exporter.go
+++ b/pgbouncer_exporter.go
@@ -42,9 +42,17 @@ const (
 
 func main() {
 	var (
-		connectionStringPointer = kingpin.Flag("pgBouncer.connectionString", "Connection string for accessing pgBouncer.").Default("postgres://postgres:@localhost:6543/pgbouncer?sslmode=disable").String()
-		listenAddress           = kingpin.Flag("web.listen-address", "Address on which to expose metrics and web interface.").Default(":9127").String()
-		metricsPath             = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").String()
+		connectionStringPointer = kingpin.Flag(
+			"pgBouncer.connectionString", "Connection string for accessing pgBouncer($PGBOUNCER_EXPORTER_CONNECTION_STRING).",
+		).Envar("PGBOUNCER_EXPORTER_CONNECTION_STRING").Default("postgres://postgres:@localhost:6543/pgbouncer?sslmode=disable").String()
+
+		listenAddress = kingpin.Flag(
+			"web.listen-address", "Address on which to expose metrics and web interface($PGBOUNCER_EXPORTER_WEB_LISTEN_ADDRESS).",
+		).Envar("PGBOUNCER_EXPORTER_WEB_LISTEN_ADDRESS").Default(":9127").String()
+
+		metricsPath = kingpin.Flag(
+			"web.telemetry-path", "Path under which to expose metrics($PGBOUNCER_EXPORTER_WEB_TELEMETRY_PATH).",
+		).Envar("PGBOUNCER_EXPORTER_WEB_TELEMETRY_PATH").Default("/metrics").String()
 	)
 
 	log.AddFlags(kingpin.CommandLine)


### PR DESCRIPTION
for https://github.com/prometheus-community/pgbouncer_exporter/issues/24

Adds support for reading configuration flags via the following environment variables:
- `$PGBOUNCER_EXPORTER_CONNECTION_STRING` for `pgBouncer.connectionString`
- `$PGBOUNCER_EXPORTER_WEB_LISTEN_ADDRESS` for `web.listen-address`
- `$PGBOUNCER_EXPORTER_WEB_TELEMETRY_PATH` for `web.telemetry-path`

also adds description of flags to README.md :) 