### PR TITLE
Add pgbouncer process metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master / unreleased
 
+* [FEATURE] Add pgbouncer process metrics
+
 ## 0.2.0 / 2020-04-29
 
 * [BUGFIX] Fix byte slice values not receiving conversion factor #18


### PR DESCRIPTION
Add an option to pass a pgboucner PID file into the exporter to collect
process metrics.

Closes: https://github.com/prometheus-community/pgbouncer_exporter/issues/26

Signed-off-by: Ben Kochie <superq@gmail.com>