### PR TITLE
Cleanup exporter metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master / unreleased
 
+* [CHANGE] Cleanup exporter metrics #33
+
 ## 0.3.0 / 2020-05-27
 
 * [CHANGE] Switch logging to promlog #29

--- a/struct.go
+++ b/struct.go
@@ -17,7 +17,6 @@ package main
 import (
 	"database/sql"
 	"fmt"
-	"sync"
 
 	"github.com/go-kit/kit/log"
 	"github.com/prometheus/client_golang/prometheus"
@@ -103,11 +102,6 @@ type ColumnMapping struct {
 // Exporter collects PgBouncer stats from the given server and exports
 // them using the prometheus metrics package.
 type Exporter struct {
-	mutex sync.RWMutex
-
-	duration, up, error prometheus.Gauge
-	totalScrapes        prometheus.Counter
-
 	metricMap map[string]MetricMapNamespace
 
 	db *sql.DB


### PR DESCRIPTION
* Remove scrape counter, covered by promhttp metrics.
* Combine up and error metrics to simplify use.
* Remove scrape duration counter, covered by `scrape_duration_seconds`.
* Use Const metric for `up` metric.

Signed-off-by: Ben Kochie <superq@gmail.com>