### PR TITLE
Export maxwait_us from SHOW POOLS

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,4 +33,5 @@ pools.sv_idle | pgbouncer_pools_server_idle_connections | Server connections idl
 pools.sv_used | pgbouncer_pools_server_used_connections | Server connections idle more than server_check_delay, needing server_check_query, shown as connection
 pools.sv_tested | pgbouncer_pools_server_testing_connections | Server connections currently running either server_reset_query or server_check_query, shown as connection
 pools.sv_login | pgbouncer_pools_server_login_connections | Server connections currently in the process of logging in, shown as connection
-pools.maxwait | pgbouncer_pools_client_maxwait_seconds | Age of oldest unserved client connection, shown as second
+pools.maxwait | pgbouncer_pools_client_maxwait_seconds | Age of oldest unserved client connection in full seconds
+pools.maxwait_us | pgbouncer_pools_client_maxwait_fractional | The fractional part of client_maxwait_seconds

--- a/collector.go
+++ b/collector.go
@@ -66,7 +66,8 @@ var (
 			"sv_used":    {GAUGE, "server_used_connections", 1, "Server connections idle more than server_check_delay, needing server_check_query, shown as connection"},
 			"sv_tested":  {GAUGE, "server_testing_connections", 1, "Server connections currently running either server_reset_query or server_check_query, shown as connection"},
 			"sv_login":   {GAUGE, "server_login_connections", 1, "Server connections currently in the process of logging in, shown as connection"},
-			"maxwait":    {GAUGE, "client_maxwait_seconds", 1, "Age of oldest unserved client connection, shown as second"},
+			"maxwait":    {GAUGE, "client_maxwait_seconds", 1, "Age of oldest unserved client connection in full seconds"},
+			"maxwait_us": {GAUGE, "client_maxwait_fractional", 1e-6, "The fractional part of client_maxwait_seconds"},
 		},
 	}
 


### PR DESCRIPTION
To avoid breaking backwards compatibility, client_maxwait_seconds still
only has the integer part.  A new metric, client_maxwait_fractional,
is introduced for the fractional part.