### PR TITLE
Expose config metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,5 @@ pools.sv_used | pgbouncer_pools_server_used_connections | Server connections idl
 pools.sv_tested | pgbouncer_pools_server_testing_connections | Server connections currently running either server_reset_query or server_check_query, shown as connection
 pools.sv_login | pgbouncer_pools_server_login_connections | Server connections currently in the process of logging in, shown as connection
 pools.maxwait | pgbouncer_pools_client_maxwait_seconds | Age of oldest unserved client connection, shown as second
+config.max_client_conn | pgbouncer_config_max_client_conn | Configured maximum number of client connections
+config.max_user_connections | pgbouncer_config_max_user_connections | Configured maximum number of server connections per user


### PR DESCRIPTION
Config metrics are not currently not exposed
by the exporter. These metrics are used in some
existing dashboards.

Config metrics being exposed:
- max_client_conn: pgbouncer_config_max_client_conn
- max_user_connections: pgbouncer_config_max_user_connections