### PR TITLE
Expose config metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,5 +34,5 @@ pools.sv_used | pgbouncer_pools_server_used_connections | Server connections idl
 pools.sv_tested | pgbouncer_pools_server_testing_connections | Server connections currently running either server_reset_query or server_check_query, shown as connection
 pools.sv_login | pgbouncer_pools_server_login_connections | Server connections currently in the process of logging in, shown as connection
 pools.maxwait | pgbouncer_pools_client_maxwait_seconds | Age of oldest unserved client connection, shown as second
-config.max_client_conn | pgbouncer_config_max_client_conn | Configured maximum number of client connections
+config.max_client_conn | pgbouncer_config_max_client_connections | Configured maximum number of client connections
 config.max_user_connections | pgbouncer_config_max_user_connections | Configured maximum number of server connections per user

--- a/README.md
+++ b/README.md
@@ -34,3 +34,5 @@ pools.sv_used | pgbouncer_pools_server_used_connections | Server connections idl
 pools.sv_tested | pgbouncer_pools_server_testing_connections | Server connections currently running either server_reset_query or server_check_query, shown as connection
 pools.sv_login | pgbouncer_pools_server_login_connections | Server connections currently in the process of logging in, shown as connection
 pools.maxwait | pgbouncer_pools_client_maxwait_seconds | Age of oldest unserved client connection, shown as second
+config.max_client_conn | pgbouncer_config_max_client_conn | Configured maximum number of client connections
+config.max_user_connections | pgbouncer_config_max_user_connections | Configured maximum number of server connections per user

--- a/collector.go
+++ b/collector.go
@@ -108,7 +108,7 @@ var (
 
 	configMap = map[string]*(prometheus.Desc){
 		"max_client_conn": prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "config", "max_client_conn"),
+			prometheus.BuildFQName(namespace, "config", "max_client_connections"),
 			"Config maximum number of client connections", nil, nil),
 		"max_user_connections": prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "config", "max_user_connections"),


### PR DESCRIPTION
Config metrics are not currently not exposed
by the exporter. These metrics are used in some
existing dashboards.

Config metrics being exposed:
- max_client_conn: pgbouncer_config_max_client_conn
- max_user_connections: pgbouncer_config_max_user_connections

Signed-off-by: kenneth-duffel <93927344+kenneth-duffel@users.noreply.github.com>