### PR TITLE
Add environment variable handling

### DIFF
--- a/pgbouncer_exporter.go
+++ b/pgbouncer_exporter.go
@@ -46,9 +46,9 @@ func main() {
 	flag.AddFlags(kingpin.CommandLine, promlogConfig)
 
 	var (
-		connectionStringPointer = kingpin.Flag("pgBouncer.connectionString", "Connection string for accessing pgBouncer.").Default("postgres://postgres:@localhost:6543/pgbouncer?sslmode=disable").String()
-		metricsPath             = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").String()
-		pidFilePath             = kingpin.Flag("pgBouncer.pid-file", pidFileHelpText).Default("").String()
+		connectionStringPointer = kingpin.Flag("pgBouncer.connectionString", "Connection string for accessing pgBouncer.").Default("postgres://postgres:@localhost:6543/pgbouncer?sslmode=disable").Envar("PGBOUNCER_EXPORTER_CONNECTION_STRING").String()
+		metricsPath             = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").Envar("PGBOUNCER_EXPORTER_METRICS_PATH").String()
+		pidFilePath             = kingpin.Flag("pgBouncer.pid-file", pidFileHelpText).Default("").Envar("PGBOUNCER_EXPORTER_PIDFILE_PATH").String()
 	)
 
 	toolkitFlags := kingpinflag.AddFlags(kingpin.CommandLine, ":9127")


### PR DESCRIPTION
For the custom commandline options environment variable handling is added. Especially the connection string comes in handy if using the exporter via container deployment so that no credentials or otherwise sensible information is visible in the commandline or process list.