### PR TITLE
Allow connection config via environment variable

### DIFF
--- a/pgbouncer_exporter.go
+++ b/pgbouncer_exporter.go
@@ -46,7 +46,7 @@ func main() {
 	flag.AddFlags(kingpin.CommandLine, promlogConfig)
 
 	var (
-		connectionStringPointer = kingpin.Flag("pgBouncer.connectionString", "Connection string for accessing pgBouncer.").Default("postgres://postgres:@localhost:6543/pgbouncer?sslmode=disable").String()
+		connectionStringPointer = kingpin.Flag("pgBouncer.connectionString", "Connection string for accessing pgBouncer.").Default("postgres://postgres:@localhost:6543/pgbouncer?sslmode=disable").Envar("PGBOUNCER_EXPORTER_CONNECTION_STRING").String()
 		metricsPath             = kingpin.Flag("web.telemetry-path", "Path under which to expose metrics.").Default("/metrics").String()
 		pidFilePath             = kingpin.Flag("pgBouncer.pid-file", pidFileHelpText).Default("").String()
 	)


### PR DESCRIPTION
For the connection option environment variable handling is added. The connection string comes in handy if using the exporter via container deployment so that no credentials or otherwise sensible information is visible in the commandline or process list.

As discussed in #132 I dropped the additional handling of `PGBOUNCER_EXPORTER_PIDFILE_PATH` and `PGBOUNCER_EXPORTER_METRICS_PATH`.