### PR TITLE
Revert auth_type guage

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -110,9 +110,6 @@ var (
 	}
 
 	configMap = map[string]*(prometheus.Desc){
-		"auth_type": prometheus.NewDesc(
-			prometheus.BuildFQName(namespace, "config", "auth_type"),
-			"Config authentication type used by pgbouncer", nil, nil),
 		"max_client_conn": prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "config", "max_client_connections"),
 			"Config maximum number of client connections", nil, nil),


### PR DESCRIPTION
The `auth_type` has non-float values like `md5` which breaks the exporter here: https://github.com/prometheus-community/pgbouncer_exporter/blob/a37997d64438360e7dc2e8d8b7f9064c2b176e13/collector.go#L228

Also fixes https://github.com/prometheus-community/pgbouncer_exporter/issues/172