### PR TITLE
Add semantic versioning to pgbouncer_exporter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.22
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/alecthomas/kingpin/v2 v2.4.0
+	github.com/blang/semver/v4 v4.0.0
 	github.com/lib/pq v1.10.9
 	github.com/prometheus/client_golang v1.20.4
 	github.com/prometheus/client_model v0.6.1

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,8 @@ github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137 h1:s6gZFSlWYmbqAu
 github.com/alecthomas/units v0.0.0-20211218093645-b94a6e3cc137/go.mod h1:OMCwj8VM1Kc9e19TLln2VL61YJF0x1XFtfdL4JdbSyE=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
+github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/coreos/go-systemd/v22 v22.5.0 h1:RrqgGjYQKalulkV8NGVIfkXQf6YYmOyiJKk8iXXhfZs=

--- a/struct.go
+++ b/struct.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/blang/semver/v4"
 	"github.com/prometheus/client_golang/prometheus"
 )
 
@@ -93,10 +94,11 @@ type MetricMap struct {
 }
 
 type ColumnMapping struct {
-	usage       columnUsage `yaml:"usage"`
-	metric      string      `yaml:"metric"`
-	factor      float64     `yaml:"factor"`
-	description string      `yaml:"description"`
+	usage       columnUsage    `yaml:"usage"`
+	metric      string         `yaml:"metric"`
+	factor      float64        `yaml:"factor"`
+	description string         `yaml:"description"`
+	minVersion  semver.Version `yaml:"min_version"`
 }
 
 // Exporter collects PgBouncer stats from the given server and exports
@@ -107,4 +109,6 @@ type Exporter struct {
 	db *sql.DB
 
 	logger *slog.Logger
+
+	version semver.Version
 }


### PR DESCRIPTION
Lays the groundwork to add version-specific attributes to the metricmaps (e.g. prepared_statements from servers is only available after 1.21.0 of pgbouncer)