### PR TITLE
Set host auth method to trust so that postgres can start

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,10 @@
-version: '2'
+version: "2"
 
 services:
   postgres:
     image: postgres:9.4
+    environment:
+      - POSTGRES_HOST_AUTH_METHOD=trust
     ports:
       - "5432"
 


### PR DESCRIPTION
Trust allows us to start it up without issues. 

Pgbouncer: Latest is also stuck at 1.5.5, so we might want to grab a newer version or change pgbouncer repos