### PR TITLE
Entrypoint to wait for PgBouncer to get ready

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,16 @@ ARG OS="linux"
 FROM quay.io/prometheus/busybox-${OS}-${ARCH}:latest
 LABEL maintainer="The Prometheus Authors <prometheus-developers@googlegroups.com>"
 
+RUN apk add --no-cache postgresql-client
+
 ARG ARCH="amd64"
 ARG OS="linux"
 COPY .build/${OS}-${ARCH}/pgbouncer_exporter /bin/pgbouncer_exporter
 COPY LICENSE                                /LICENSE
 
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
 USER       nobody
-ENTRYPOINT ["/bin/pgbouncer_exporter"]
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 EXPOSE     9127

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+set -e
+
+# Set defaults as fallback if vars are not set
+: "${PGBOUNCER_HOST:=127.0.0.1}"
+: "${PGBOUNCER_PORT:=6432}"
+
+# Wait for pgbouncer to become available
+until pg_isready -h "$PGBOUNCER_HOST" -p "$PGBOUNCER_PORT"; do
+  echo "Waiting for PgBouncer on $PGBOUNCER_HOST:$PGBOUNCER_PORT..."
+  sleep 2
+done
+
+# Launch the exporter
+exec /bin/pgbouncer_exporter "$@"


### PR DESCRIPTION
When pgbouncer-exporter is running in a Kubernetes pod with PgBouncer, PgBouncer might start up slower than the exporter, then the exporter fails with the following error:

```time=2025-06-16T13:56:13.798Z level=ERROR source=/app/collector.go:141 msg="error setting up DB connection" err="error pinging pgbouncer: dial tcp [::1]:6543: connect: connection refused"```

The entrypoint only allows the exporter to start once PgBouncer is up and running.