### PR TITLE
fix(collector): restore reserve_pool metric on PgBouncer >= 1.24

### DIFF
--- a/collector.go
+++ b/collector.go
@@ -38,6 +38,7 @@ var (
 			"force_user":          {LABEL, "N/A", 1, "N/A"},
 			"pool_size":           {GAUGE, "pool_size", 1, "Maximum number of server connections"},
 			"reserve_pool":        {GAUGE, "reserve_pool", 1, "Maximum number of additional connections for this database"},
+			"reserve_pool_size":   {GAUGE, "reserve_pool", 1, "Maximum number of additional connections for this database"},
 			"pool_mode":           {LABEL, "N/A", 1, "N/A"},
 			"max_connections":     {GAUGE, "max_connections", 1, "Maximum number of allowed connections for this database"},
 			"current_connections": {GAUGE, "current_connections", 1, "Current number of connections for this database"},

--- a/collector_test.go
+++ b/collector_test.go
@@ -235,6 +235,30 @@ func TestQueryShowDatabases(t *testing.T) {
 	testQueryNamespaceMapping(t, "databases", rows, expected)
 }
 
+func TestQueryShowDatabasesReservePool(t *testing.T) {
+	// PgBouncer < 1.24 exposes the column as reserve_pool
+	rows := sqlmock.NewRows([]string{"name", "host", "port", "database", "reserve_pool"}).
+		AddRow("pg0_db", "10.10.10.1", "5432", "pg0", 5)
+
+	expected := []MetricResult{
+		{labels: labelMap{"name": "pg0_db", "host": "10.10.10.1", "port": "5432", "database": "pg0", "force_user": "", "pool_mode": ""}, metricType: dto.MetricType_GAUGE, value: 5},
+	}
+
+	testQueryNamespaceMapping(t, "databases", rows, expected)
+}
+
+func TestQueryShowDatabasesReservePoolSize(t *testing.T) {
+	// PgBouncer >= 1.24 renamed the column to reserve_pool_size
+	rows := sqlmock.NewRows([]string{"name", "host", "port", "database", "reserve_pool_size"}).
+		AddRow("pg0_db", "10.10.10.1", "5432", "pg0", 5)
+
+	expected := []MetricResult{
+		{labels: labelMap{"name": "pg0_db", "host": "10.10.10.1", "port": "5432", "database": "pg0", "force_user": "", "pool_mode": ""}, metricType: dto.MetricType_GAUGE, value: 5},
+	}
+
+	testQueryNamespaceMapping(t, "databases", rows, expected)
+}
+
 func TestQueryShowStats(t *testing.T) {
 	// columns are listed in the order PgBouncers exposes them, a value of -1 means pgbouncer_exporter does not expose this value as a metric
 	rows := sqlmock.NewRows([]string{"database",


### PR DESCRIPTION
Hi

In this PR I'd like to fix the missing `pgbouncer_databases_reserve_pool` metric on recent PgBouncer versions.

PgBouncer 1.24.0 renamed the `reserve_pool` column in `SHOW DATABASES` to `reserve_pool_size` (https://github.com/pgbouncer/pgbouncer/pull/1232). The exporter only mapped the old column name, so the `pgbouncer_databases_reserve_pool` metric silently stopped being emitted on PgBouncer 1.24+.

The fix adds a mapping for `reserve_pool_size` next to the existing `reserve_pool` entry, both pointing at the same metric name. The exporter iterates over the actual columns returned by pgbouncer, and the two names are mutually exclusive across versions, so the metric continues to be emitted exactly once per database row regardless of pgbouncer version. Tests covering both column names are included.

Refs: https://github.com/prometheus-community/pgbouncer_exporter/issues/220